### PR TITLE
✨ Update Jenkinsfile with new UPSTREAM version parameters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,8 +7,8 @@ hose {
     RELEASETIMEOUT = 80
     ATTIMEOUT = 90
     INSTALLTIMEOUT = 90
-    VERSIONING_TYPE = "stratioVersion-2-3"
-    UPSTREAM_VERSION = '0.42'
+    VERSIONING_TYPE = "stratioVersion-3-3"
+    UPSTREAM_VERSION = '0.42.2'
 
     DEV = { config ->
         doDockers(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,8 +7,8 @@ hose {
     RELEASETIMEOUT = 80
     ATTIMEOUT = 90
     INSTALLTIMEOUT = 90
-    FREESTYLE_BRANCHING = true
-    UPSTREAM_VERSION = '0.42.2'
+    VERSIONING_TYPE = "stratioVersion-2-3"
+    UPSTREAM_VERSION = '0.42'
 
     DEV = { config ->
         doDockers(


### PR DESCRIPTION
New Jenkinsfile parameters to use upstream versioning. FREESTYLE_BRANCHING will be removed and there is a new variable 
VERSIONING_TYPE = 'stratioVersion-3-3', where the digits are the number of digit groups of each version part. 
E.g.: for the brach branch-0.42-0.1, we will have VERSIONING_TYPE = 'stratioVersion-3-3', 
because our final version will have something like 0.42.2-0.1.0
